### PR TITLE
Slide typo fixes

### DIFF
--- a/intro-to-go.slide
+++ b/intro-to-go.slide
@@ -214,7 +214,7 @@ http://blog.urth.org/
 - `uint`, `uint8`, 16, 32, 64
 - `int`, `int8`, 16, 32, 64
 - `float32`, `float64`
-- `complex`, `complex64`, `complex128`
+- `complex64`, `complex128`
 - `string` - Unicode everywhere - "foo, 酒廊"
 - `rune` - one Unicode code point - '廊'
 - `byte` - a single 8-bit value
@@ -365,7 +365,7 @@ http://blog.urth.org/
         "strconv"
     )
 
-    arg1, err := strconf.ParseInt(os.Args[1], 10, 64)
+    arg1, err := strconv.ParseInt(os.Args[1], 10, 64)
 
 - `strconv.ParseInt` takes the string to parse, the base (2, 10, etc.), and the bit size (32, 64)
 - It returns an int64 and an error


### PR DESCRIPTION
Hey Dave,

Some typos fixes from the intro-to-go class:
- no `complex` type
- strconv => strconf

Cheers,
Fitz
